### PR TITLE
Add feed alias support for FeedReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ Some interesting modules you might consider adding to get you started:
 * [Transmission](https://wtfutil.com/modules/transmission/)
 * [Trello](https://wtfutil.com/modules/trello/)
 
+FeedReader allows mapping long feed URLs to short titles using `feedAliases`:
+
+```yaml
+feedreader:
+  feeds:
+    - https://feeds.bbci.co.uk/news/rss.xml
+  feedAliases:
+    https://feeds.bbci.co.uk/news/rss.xml: BBC
+```
+
 ## Getting Bugs Fixed or Features Added
 
 WTF is open-source software, informally maintained by a small collection of volunteers who come and go at their leisure. There are absolutely no guarantees that, even if an issue is opened for them, bugs will be fixed or features added.

--- a/cfg/default_config_file.go
+++ b/cfg/default_config_file.go
@@ -52,6 +52,8 @@ const defaultConfigFile = `wtf:
       enabled: true
       feeds:
       - https://feeds.bbci.co.uk/news/rss.xml
+      feedAliases:
+        https://feeds.bbci.co.uk/news/rss.xml: BBC
       feedLimit: 10
       position:
         top: 1

--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -28,14 +28,15 @@ type Settings struct {
 
 	colors
 
-	feeds           []string        `help:"An array of RSS and Atom feed URLs"`
-	feedLimit       int             `help:"The maximum number of stories to display for each feed"`
-	showSource      bool            `help:"Wether or not to show feed source in front of item titles." values:"true or false" optional:"true" default:"true"`
-	showPublishDate bool            `help:"Wether or not to show publish date in front of item titles." values:"true or false" optional:"true" default:"false"`
-	dateFormat      string          `help:"Date format to use for publish dates" values:"Any valid Go time layout which is handled by Time.Format" optional:"true" default:"Jan 02"`
-	credentials     map[string]auth `help:"Map of private feed URLs with required authentication credentials"`
-	disableHTTP2    bool            `help:"Wether or not to use the HTTP/2 protocol. Certain sites, such as reddit.com, will not work unless HTTP/2 is disabled." values:"true or false" optional:"true" default:"false"`
-	userAgent       string          `help:"HTTP User-Agent to use when fetching RSS feeds." optional:"true"`
+	feeds           []string          `help:"An array of RSS and Atom feed URLs"`
+	aliases         map[string]string `help:"Map of feed URLs to short titles"`
+	feedLimit       int               `help:"The maximum number of stories to display for each feed"`
+	showSource      bool              `help:"Wether or not to show feed source in front of item titles." values:"true or false" optional:"true" default:"true"`
+	showPublishDate bool              `help:"Wether or not to show publish date in front of item titles." values:"true or false" optional:"true" default:"false"`
+	dateFormat      string            `help:"Date format to use for publish dates" values:"Any valid Go time layout which is handled by Time.Format" optional:"true" default:"Jan 02"`
+	credentials     map[string]auth   `help:"Map of private feed URLs with required authentication credentials"`
+	disableHTTP2    bool              `help:"Wether or not to use the HTTP/2 protocol. Certain sites, such as reddit.com, will not work unless HTTP/2 is disabled." values:"true or false" optional:"true" default:"false"`
+	userAgent       string            `help:"HTTP User-Agent to use when fetching RSS feeds." optional:"true"`
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -43,6 +44,7 @@ func NewSettingsFromYAML(name string, ymlConfig, globalConfig *config.Config) *S
 	settings := &Settings{
 		Common:          cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 		feeds:           utils.ToStrs(ymlConfig.UList("feeds")),
+		aliases:         utils.MapToStrs(ymlConfig.UMap("feedAliases")),
 		feedLimit:       ymlConfig.UInt("feedLimit", -1),
 		showSource:      ymlConfig.UBool("showSource", true),
 		showPublishDate: ymlConfig.UBool("showPublishDate", false),

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -162,9 +162,14 @@ func (widget *Widget) fetchForFeed(feedURL string) ([]*FeedItem, error) {
 			break
 		}
 
+		sourceTitle := feed.Title
+		if alias, ok := widget.settings.aliases[feedURL]; ok {
+			sourceTitle = alias
+		}
+
 		feedItem := &FeedItem{
 			item:        gofeedItem,
-			sourceTitle: feed.Title,
+			sourceTitle: sourceTitle,
 			viewed:      false,
 		}
 


### PR DESCRIPTION
## Summary
- support feed aliases in FeedReader Settings and widget
- load `feedAliases` from YAML
- show alias example in default config
- document alias usage in README

## Testing
- `go test ./...` *(fails: cannot access proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_68792ed29e508322961caca0d816d137