### PR TITLE
Enable multiline feedreader items

### DIFF
--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -31,6 +31,7 @@ type Settings struct {
 	feeds           []string        `help:"An array of RSS and Atom feed URLs"`
 	feedLimit       int             `help:"The maximum number of stories to display for each feed"`
 	maxHeight       int             `help:"Maximum number of lines to display for each item" optional:"true" default:"3"`
+	minHeight       int             `help:"Minimum number of lines to display for each item" optional:"true" default:"2"`
 	showSource      bool            `help:"Wether or not to show feed source in front of item titles." values:"true or false" optional:"true" default:"true"`
 	showPublishDate bool            `help:"Wether or not to show publish date in front of item titles." values:"true or false" optional:"true" default:"false"`
 	dateFormat      string          `help:"Date format to use for publish dates" values:"Any valid Go time layout which is handled by Time.Format" optional:"true" default:"Jan 02"`
@@ -46,6 +47,7 @@ func NewSettingsFromYAML(name string, ymlConfig, globalConfig *config.Config) *S
 		feeds:           utils.ToStrs(ymlConfig.UList("feeds")),
 		feedLimit:       ymlConfig.UInt("feedLimit", -1),
 		maxHeight:       ymlConfig.UInt("maxHeight", 3),
+		minHeight:       ymlConfig.UInt("minHeight", 2),
 		showSource:      ymlConfig.UBool("showSource", true),
 		showPublishDate: ymlConfig.UBool("showPublishDate", false),
 		dateFormat:      ymlConfig.UString("dateFormat", "Jan 02"),

--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -30,6 +30,7 @@ type Settings struct {
 
 	feeds           []string        `help:"An array of RSS and Atom feed URLs"`
 	feedLimit       int             `help:"The maximum number of stories to display for each feed"`
+	maxHeight       int             `help:"Maximum number of lines to display for each item" optional:"true" default:"3"`
 	showSource      bool            `help:"Wether or not to show feed source in front of item titles." values:"true or false" optional:"true" default:"true"`
 	showPublishDate bool            `help:"Wether or not to show publish date in front of item titles." values:"true or false" optional:"true" default:"false"`
 	dateFormat      string          `help:"Date format to use for publish dates" values:"Any valid Go time layout which is handled by Time.Format" optional:"true" default:"Jan 02"`
@@ -44,6 +45,7 @@ func NewSettingsFromYAML(name string, ymlConfig, globalConfig *config.Config) *S
 		Common:          cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 		feeds:           utils.ToStrs(ymlConfig.UList("feeds")),
 		feedLimit:       ymlConfig.UInt("feedLimit", -1),
+		maxHeight:       ymlConfig.UInt("maxHeight", 3),
 		showSource:      ymlConfig.UBool("showSource", true),
 		showPublishDate: ymlConfig.UBool("showPublishDate", false),
 		dateFormat:      ymlConfig.UString("dateFormat", "Jan 02"),

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -202,6 +202,12 @@ func (widget *Widget) content() (string, string, bool) {
 		displayText := widget.getShowText(feedItem, rowColor)
 
 		lines := strings.Split(displayText, "\n")
+
+		moveTitle := widget.settings.maxHeight == 0 || widget.settings.maxHeight >= 2
+		if moveTitle && len(lines) > 0 {
+			lines = append([]string{""}, lines...)
+		}
+
 		if widget.settings.maxHeight > 0 && len(lines) > widget.settings.maxHeight {
 			lines = lines[:widget.settings.maxHeight]
 		}
@@ -210,9 +216,16 @@ func (widget *Widget) content() (string, string, bool) {
 		}
 
 		if len(lines) > 0 {
-			lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, idx+1, lines[0])
-			for i := 1; i < len(lines); i++ {
-				lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
+			if moveTitle {
+				lines[0] = fmt.Sprintf("[%s]%2d.[white]", rowColor, idx+1)
+				for i := 1; i < len(lines); i++ {
+					lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
+				}
+			} else {
+				lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, idx+1, lines[0])
+				for i := 1; i < len(lines); i++ {
+					lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
+				}
 			}
 		}
 

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -87,6 +87,9 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.P
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
+	widget.View.SetWrap(true)
+	widget.View.SetWordWrap(true)
+
 	return widget
 }
 
@@ -198,14 +201,19 @@ func (widget *Widget) content() (string, string, bool) {
 
 		displayText := widget.getShowText(feedItem, rowColor)
 
-		row := fmt.Sprintf(
-			"[%s]%2d. %s[white]",
-			rowColor,
-			idx+1,
-			displayText,
-		)
+		lines := strings.Split(displayText, "\n")
+		if widget.settings.maxHeight > 0 && len(lines) > widget.settings.maxHeight {
+			lines = lines[:widget.settings.maxHeight]
+		}
 
-		str += utils.HighlightableHelper(widget.View, row, idx, len(feedItem.item.Title))
+		if len(lines) > 0 {
+			lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, idx+1, lines[0])
+			for i := 1; i < len(lines); i++ {
+				lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
+			}
+		}
+
+		str += utils.HighlightableBlockHelper(widget.View, lines, idx)
 	}
 
 	return title, str, false

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -216,7 +216,7 @@ func (widget *Widget) content() (string, string, bool) {
 		str += utils.HighlightableBlockHelper(widget.View, lines, idx)
 	}
 
-	return title, str, false
+	return title, str, true
 }
 
 func (widget *Widget) getShowText(feedItem *FeedItem, rowColor string) string {

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -205,6 +205,9 @@ func (widget *Widget) content() (string, string, bool) {
 		if widget.settings.maxHeight > 0 && len(lines) > widget.settings.maxHeight {
 			lines = lines[:widget.settings.maxHeight]
 		}
+		for len(lines) < widget.settings.minHeight {
+			lines = append(lines, "")
+		}
 
 		if len(lines) > 0 {
 			lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, idx+1, lines[0])

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -204,8 +204,24 @@ func (widget *Widget) content() (string, string, bool) {
 		lines := strings.Split(displayText, "\n")
 
 		moveTitle := widget.settings.maxHeight == 0 || widget.settings.maxHeight >= 2
-		if moveTitle && len(lines) > 0 {
-			lines = append([]string{""}, lines...)
+		if moveTitle && widget.showType != SHOW_LINK && len(lines) > 0 {
+			space := regexp.MustCompile(`\s+`)
+
+			source := ""
+			publishDate := ""
+
+			if widget.settings.showSource && feedItem.sourceTitle != "" {
+				source = fmt.Sprintf("[%s]%s ", widget.settings.source, feedItem.sourceTitle)
+			}
+			if widget.settings.showPublishDate && feedItem.item.Published != "" {
+				publishDate = fmt.Sprintf("[%s]%s ", widget.settings.publishDate, feedItem.item.PublishedParsed.Format(widget.settings.dateFormat))
+			}
+
+			titleText := space.ReplaceAllString(feedItem.item.Title, " ")
+			prefixLine := html.UnescapeString(source + publishDate)
+			titleLine := html.UnescapeString(fmt.Sprintf("[%s]%s", rowColor, titleText))
+
+			lines = append([]string{prefixLine, titleLine}, lines[1:]...)
 		}
 
 		if widget.settings.maxHeight > 0 && len(lines) > widget.settings.maxHeight {
@@ -216,16 +232,9 @@ func (widget *Widget) content() (string, string, bool) {
 		}
 
 		if len(lines) > 0 {
-			if moveTitle {
-				lines[0] = fmt.Sprintf("[%s]%2d.[white]", rowColor, idx+1)
-				for i := 1; i < len(lines); i++ {
-					lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
-				}
-			} else {
-				lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, idx+1, lines[0])
-				for i := 1; i < len(lines); i++ {
-					lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
-				}
+			lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, idx+1, lines[0])
+			for i := 1; i < len(lines); i++ {
+				lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
 			}
 		}
 

--- a/modules/feedreader/widget_test.go
+++ b/modules/feedreader/widget_test.go
@@ -1,9 +1,14 @@
 package feedreader
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mmcdole/gofeed"
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 	"gotest.tools/assert"
 )
 
@@ -81,4 +86,34 @@ func Test_getShowText(t *testing.T) {
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+func Test_widget_content_block(t *testing.T) {
+	app := tview.NewApplication()
+	w := NewWidget(app, make(chan bool), tview.NewPages(), &Settings{Common: &cfg.Common{}, maxHeight: 3})
+	w.showType = SHOW_CONTENT
+	w.stories = []*FeedItem{
+		{
+			item: &gofeed.Item{
+				Title:   "Cats",
+				Content: "<pre>one\ntwo\nthree\nfour</pre>",
+			},
+		},
+	}
+
+	title, content, wrap := w.content()
+
+	rowColor := w.RowColor(0)
+	display := w.getShowText(w.stories[0], rowColor)
+	lines := strings.Split(display, "\n")
+	lines = lines[:w.settings.maxHeight]
+	lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, 1, lines[0])
+	for i := 1; i < len(lines); i++ {
+		lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
+	}
+	expected := utils.HighlightableBlockHelper(w.View, lines, 0)
+
+	assert.Equal(t, w.CommonSettings().Title, title)
+	assert.Equal(t, expected, content)
+	assert.Equal(t, false, wrap)
 }

--- a/modules/feedreader/widget_test.go
+++ b/modules/feedreader/widget_test.go
@@ -106,10 +106,22 @@ func Test_widget_content_block(t *testing.T) {
 	rowColor := w.RowColor(0)
 	display := w.getShowText(w.stories[0], rowColor)
 	lines := strings.Split(display, "\n")
-	lines = lines[:w.settings.maxHeight]
-	lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, 1, lines[0])
-	for i := 1; i < len(lines); i++ {
-		lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
+	if w.settings.maxHeight == 0 || w.settings.maxHeight >= 2 {
+		lines = append([]string{""}, lines...)
+	}
+	if w.settings.maxHeight > 0 && len(lines) > w.settings.maxHeight {
+		lines = lines[:w.settings.maxHeight]
+	}
+	if w.settings.maxHeight == 0 || w.settings.maxHeight >= 2 {
+		lines[0] = fmt.Sprintf("[%s]%2d.[white]", rowColor, 1)
+		for i := 1; i < len(lines); i++ {
+			lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
+		}
+	} else {
+		lines[0] = fmt.Sprintf("[%s]%2d. %s[white]", rowColor, 1, lines[0])
+		for i := 1; i < len(lines); i++ {
+			lines[i] = fmt.Sprintf("[%s]%s[white]", rowColor, lines[i])
+		}
 	}
 	expected := utils.HighlightableBlockHelper(w.View, lines, 0)
 
@@ -135,4 +147,31 @@ func Test_widget_content_min_height(t *testing.T) {
 	expectedLines := 2
 	actualLines := strings.Count(content, "\n")
 	assert.Equal(t, expectedLines, actualLines)
+}
+
+func Test_widget_title_second_line(t *testing.T) {
+	app := tview.NewApplication()
+	w := NewWidget(app, make(chan bool), tview.NewPages(), &Settings{Common: &cfg.Common{}, maxHeight: 3})
+	w.showType = SHOW_CONTENT
+	w.stories = []*FeedItem{
+		{
+			item: &gofeed.Item{
+				Title:   "Cats",
+				Content: "<pre>meow</pre>",
+			},
+		},
+	}
+
+	_, content, _ := w.content()
+
+	// strip highlight regions and padding for easier comparison
+	cleaned := utils.StripColorTags(strings.ReplaceAll(content, "[\"0\"][\"\"]", ""))
+	lines := strings.Split(cleaned, "\n")
+
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d", len(lines))
+	}
+
+	expectedTitle := "Cats           "
+	assert.Equal(t, expectedTitle, lines[1])
 }

--- a/modules/feedreader/widget_test.go
+++ b/modules/feedreader/widget_test.go
@@ -117,3 +117,22 @@ func Test_widget_content_block(t *testing.T) {
 	assert.Equal(t, expected, content)
 	assert.Equal(t, true, wrap)
 }
+
+func Test_widget_content_min_height(t *testing.T) {
+	app := tview.NewApplication()
+	w := NewWidget(app, make(chan bool), tview.NewPages(), &Settings{Common: &cfg.Common{}, minHeight: 2})
+	w.showType = SHOW_TITLE
+	w.stories = []*FeedItem{
+		{
+			item: &gofeed.Item{
+				Title: "Cats",
+			},
+		},
+	}
+
+	_, content, _ := w.content()
+
+	expectedLines := 2
+	actualLines := strings.Count(content, "\n")
+	assert.Equal(t, expectedLines, actualLines)
+}

--- a/modules/feedreader/widget_test.go
+++ b/modules/feedreader/widget_test.go
@@ -115,5 +115,5 @@ func Test_widget_content_block(t *testing.T) {
 
 	assert.Equal(t, w.CommonSettings().Title, title)
 	assert.Equal(t, expected, content)
-	assert.Equal(t, false, wrap)
+	assert.Equal(t, true, wrap)
 }

--- a/utils/text.go
+++ b/utils/text.go
@@ -79,6 +79,28 @@ func HighlightableHelper(view *tview.TextView, input string, idx, offset int) st
 	return fmtStr
 }
 
+// HighlightableBlockHelper pads each line of a multiline block with spaces so
+// that the block spans the full width of the view. It wraps the entire block in
+// a region so that all lines are highlighted together when selected.
+func HighlightableBlockHelper(view *tview.TextView, lines []string, idx int) string {
+	_, _, w, _ := view.GetInnerRect()
+
+	fmtStr := fmt.Sprintf(`["%d"][""]`, idx)
+
+	for i, line := range lines {
+		visibleWidth := len([]rune(StripColorTags(line)))
+		fmtStr += line
+		fmtStr += RowPadding(visibleWidth, w)
+		if i < len(lines)-1 {
+			fmtStr += "\n"
+		}
+	}
+
+	fmtStr += `[""]` + "\n"
+
+	return fmtStr
+}
+
 // RowPadding returns a padding for a row to make it the full width of the containing widget.
 // Useful for ensuring row highlighting spans the full width (I suspect tcell has a better
 // way to do this, but I haven't yet found it)

--- a/utils/text_test.go
+++ b/utils/text_test.go
@@ -96,6 +96,16 @@ func Test_HighlightableHelper(t *testing.T) {
 	assert.Equal(t, "[\"0\"][\"\"]cats          [\"\"]\n", actual)
 }
 
+func Test_HighlightableBlockHelper(t *testing.T) {
+	view := tview.NewTextView()
+	lines := []string{"cats", "dogs"}
+
+	actual := HighlightableBlockHelper(view, lines, 0)
+
+	expected := "[\"0\"][\"\"]cats           \ndogs           [\"\"]\n"
+	assert.Equal(t, expected, actual)
+}
+
 func Test_RowPadding(t *testing.T) {
 	assert.Equal(t, "", RowPadding(0, 0))
 	assert.Equal(t, "", RowPadding(5, 2))


### PR DESCRIPTION
## Summary
- add `maxHeight` setting for feedreader items
- highlight multiline blocks with `HighlightableBlockHelper`
- wrap feedreader widget text
- support multiline items in content
- test feedreader block formatting
- test new block helper

## Testing
- `go test ./utils -run Test_HighlightableBlockHelper -v`
- `go test ./modules/feedreader -run Test_widget_content_block -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a8d9b94208322a136181f9e61a483